### PR TITLE
修复2个bug+更改格式

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -1,0 +1,137 @@
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <numeric>
+#include <thread>
+#include <vector>
+
+#include "../zzy-thread-pool/thread_pool.h"
+#include "CppUnitTest.h"
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std;
+using namespace ztools;
+
+namespace UnitTest
+{
+	TEST_CLASS(UnitTest)
+	{
+	public:
+		
+		TEST_METHOD(test_thread_pool_construct_and_destroy)
+		{
+			try {
+				ThreadPool pool1;
+				ThreadPool pool2(1s);
+				ThreadPool pool3(0, 20, 2s);
+			} catch (...) {
+				Assert::Fail(L"Catch Exception");
+			}
+		}
+
+		TEST_METHOD(test_thread_pool_add_task)
+		{
+			try {
+				ThreadPool pool;
+				auto result = pool.add_task([]() { return 100; });
+				Assert::AreEqual(100, result.get(), L"The result isn\'t correct.");
+			} catch (...) {
+				Assert::Fail(L"Catch Exception");
+			}
+		}
+
+		TEST_METHOD(test_thread_pool_add_loop)
+		{
+			try {
+				ThreadPool pool;
+				vector<int> arr(100);
+				auto add_one = [](int& e) { ++e; };
+				auto waiter = pool.add_loop(arr.begin(), arr.end(), add_one);
+				waiter.wait();
+				Assert::AreEqual(
+					100,
+					accumulate(arr.begin(), arr.end(), 0),
+					L"The result isn\'t correct."
+				);
+			} catch (...) {
+				Assert::Fail(L"Catch exception.");
+			}
+		}
+
+		TEST_METHOD(test_thread_pool_add_loop_n)
+		{
+			try {
+				ThreadPool pool;
+				vector<atomic_int> arr(100);
+				auto waiter1 = pool.add_loop_n(arr.begin(), 100, [](atomic_int& e) { ++e; });
+				auto waiter2 = pool.add_loop_n(200, arr.begin(), 100, [](atomic_int& e) { ++e; });
+				waiter1.wait();
+				waiter2.wait();
+				Assert::AreEqual(
+					200,
+					accumulate(arr.begin(), arr.end(), 0),
+					L"The result isn\'t correct."
+				);
+			} catch (...) {
+				Assert::Fail(L"Catch exception.");
+			}
+		}
+
+		TEST_METHOD(test_thread_pool_wait_all)
+		{
+			try {
+				ThreadPool pool;
+				atomic_uint result = 0;
+				for (int i = 1; i <= 10000; ++i) {
+					pool.add_task(
+						[](atomic_uint& data, int add_value) {
+							data.fetch_add(add_value, memory_order_relaxed);
+						},
+						ref(result),
+						i
+					);
+				}
+
+				pool.wait_all();
+
+				unsigned reference_result = 0;
+				for (int i = 1; i <= 10000; ++i) {
+					reference_result += i;
+				}
+
+				Assert::AreEqual(
+					reference_result,
+					result.load(memory_order_relaxed),
+					L"The result isn\'t correct"
+				);
+			} catch (...) {
+				Assert::Fail(L"Catch exception.");
+			}
+		}
+
+		TEST_METHOD(test_thread_pool_dynamic_threads_number)
+		{
+			try {
+				ThreadPool pool(100ms);
+				for (int i = 0; i < 1000; ++i) {
+					pool.add_task(
+						this_thread::sleep_for<chrono::milliseconds::rep,
+						chrono::milliseconds::period>,
+						1ms
+					);
+				}
+
+				this_thread::sleep_for(1500ms);
+
+				for (int i = 0; i < 1000; ++i) {
+					pool.add_task(
+						this_thread::sleep_for<chrono::milliseconds::rep,
+						chrono::milliseconds::period>,
+						1ms
+					);
+				}
+			} catch (...) {
+				Assert::Fail(L"Catch exception.");
+			}
+		}
+	};
+}

--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>UnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\zzy-thread-pool\thread_pool.cpp" />
+    <ClCompile Include="UnitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\zzy-thread-pool\zzy-thread-pool.vcxproj">
+      <Project>{a3524139-a710-467f-a41a-a470d854e244}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/UnitTest/UnitTest.vcxproj.filters
+++ b/UnitTest/UnitTest.vcxproj.filters
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="源文件">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="头文件">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="资源文件">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="UnitTest.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="..\zzy-thread-pool\thread_pool.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/zzy-thread-pool.sln
+++ b/zzy-thread-pool.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zzy-thread-pool", "zzy-thread-pool\zzy-thread-pool.vcxproj", "{A3524139-A710-467F-A41A-A470D854E244}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnitTest", "UnitTest\UnitTest.vcxproj", "{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -21,6 +23,14 @@ Global
 		{A3524139-A710-467F-A41A-A470D854E244}.Release|x64.Build.0 = Release|x64
 		{A3524139-A710-467F-A41A-A470D854E244}.Release|x86.ActiveCfg = Release|Win32
 		{A3524139-A710-467F-A41A-A470D854E244}.Release|x86.Build.0 = Release|Win32
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Debug|x64.ActiveCfg = Debug|x64
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Debug|x64.Build.0 = Debug|x64
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Debug|x86.ActiveCfg = Debug|Win32
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Debug|x86.Build.0 = Debug|Win32
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Release|x64.ActiveCfg = Release|x64
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Release|x64.Build.0 = Release|x64
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Release|x86.ActiveCfg = Release|Win32
+		{D2432882-DC83-4CDB-8F5D-E09A07A8CA38}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/zzy-thread-pool/test.cpp
+++ b/zzy-thread-pool/test.cpp
@@ -1,23 +1,24 @@
 #include <iostream>
-#include <vector>
-#include "thread_pool.h"
-using std::cout;
-using std::launch;
-using std::vector;
-using std::async;
 
-ztools::ThreadPool pool;
+#include "thread_pool.h"
+using ztools::ThreadPool;
+using namespace std;
 
 int main()
 {
-    vector<int> arr(100);
-    pool.add_loop(arr.begin(), arr.end(), [](int& e) { ++e; });
-    pool.add_loop_n(arr.begin(), arr.size(), [](int& e) { ++e; });
-    pool.wait_all();
-
-    for (auto& e : arr) {
-        cout << e << ' ';
+    ThreadPool pool;
+    atomic_int result{ 0 };
+    for (int i = 1; i <= 100; ++i) {
+        pool.add_task(
+            [](atomic_int& data, int add_value) {
+                data.fetch_add(add_value, memory_order_relaxed);
+            },
+            ref(result), i
+        );
     }
+
+    pool.wait_all();
+    cout << result.load(memory_order_relaxed) << '\n';
 
     return 0;
 }

--- a/zzy-thread-pool/thread_pool.cpp
+++ b/zzy-thread-pool/thread_pool.cpp
@@ -3,16 +3,88 @@ using std::memory_order_relaxed;
 using std::memory_order_release;
 using std::cv_status;
 using std::function;
+using std::lock_guard;
 using std::mutex;
+using std::size_t;
+using std::thread;
 using std::unique_lock;
+using std::max;
 #ifdef _MSC_VER
 #pragma warning(disable : 4455)
 using std::operator""s;
 #pragma warning(default : 4455)
 #endif
+namespace chrono = std::chrono;
 namespace this_thread = std::this_thread;
 
 namespace ztools {
+    LoopWaiter::Wrapper::Wrapper(size_t tasks_count)
+        : count(tasks_count) {}
+
+    LoopWaiter::LoopWaiter() noexcept
+        : m_status(nullptr) {}
+
+    LoopWaiter::LoopWaiter(size_t tasks_number)
+        : m_status(std::make_shared<Wrapper>(tasks_number)) {}
+
+    ThreadPool::ThreadPool(
+        unsigned min_threads_number,
+        unsigned max_threads_number,
+        std::chrono::steady_clock::duration timeout_len
+    )
+        : m_threads_number(0)
+        , m_free_threads_number(0)
+        , m_added_tasks_number(0)
+        , m_finished_tasks_number(0)
+        , m_stop(false)
+        , m_min_threads_number(min_threads_number)
+        , m_max_threads_number(max_threads_number)
+        , m_timeout_len(timeout_len)
+    {
+        using std::thread;
+        using std::ref;
+
+        for (unsigned i = 0; i < min_threads_number; ++i) {
+            create_thread();
+        }
+    }
+
+    ThreadPool::ThreadPool()
+        : ThreadPool(
+            max(thread::hardware_concurrency() / 2, 1U),
+            thread::hardware_concurrency()
+        ) {}
+
+    ThreadPool::ThreadPool(chrono::steady_clock::duration timeout_len)
+        : ThreadPool(
+            max(thread::hardware_concurrency() / 2, 1U),
+            thread::hardware_concurrency(),
+            timeout_len
+        ) {}
+
+    ThreadPool::~ThreadPool()
+    {
+
+        {
+            lock_guard<mutex> lock(m_mutex);
+            m_stop = true;
+        }
+
+        m_scheduler.notify_all();
+
+        while (m_threads_number > 0) {
+            this_thread::yield();
+        }
+    }
+
+    void ThreadPool::wait_all()
+    {
+        while (!(m_tasks.empty() && m_added_tasks_number.load(memory_order_relaxed) ==
+            m_finished_tasks_number.load(memory_order_relaxed))) {
+            this_thread::yield();
+        }
+    }
+
     void ThreadPool::executor_func(ThreadPool& pool) noexcept
     {
         for (;;) {
@@ -55,6 +127,7 @@ namespace ztools {
             pool.m_free_threads_number.fetch_sub(1, memory_order_relaxed);
             task();
             pool.m_free_threads_number.fetch_add(1, memory_order_release);
+            pool.m_finished_tasks_number.fetch_add(1, memory_order_relaxed);
         }
     }
 }

--- a/zzy-thread-pool/thread_pool.h
+++ b/zzy-thread-pool/thread_pool.h
@@ -16,7 +16,6 @@
 #include <thread>
 #include <type_traits>
 #include <utility>
-#include <vector>
 namespace ztools {
     struct Task
     {
@@ -26,10 +25,7 @@ namespace ztools {
 
     struct TaskPriorityLess
     {
-        bool operator()(const Task& left, const Task& right) const noexcept
-        {
-            return left.priority < right.priority;
-        }
+        inline bool operator()(const Task& left, const Task& right) const noexcept;
     };
 
     class LoopWaiter
@@ -37,9 +33,7 @@ namespace ztools {
     private:
         struct Wrapper {
             Wrapper() = default;
-            Wrapper(std::size_t tasks_count)
-                : count(tasks_count) {}
-
+            Wrapper(std::size_t tasks_count);
             ~Wrapper() = default;
 
             std::atomic_size_t count;
@@ -47,48 +41,18 @@ namespace ztools {
             std::condition_variable waiter;
         };
     public:
-        LoopWaiter() noexcept
-            : m_status(nullptr) {}
-
+        LoopWaiter() noexcept;
         LoopWaiter(const LoopWaiter&) noexcept = default;
-        LoopWaiter(size_t tasks_number)
-            : m_status(std::make_shared<Wrapper>(tasks_number)) {}
-
+        LoopWaiter(LoopWaiter&&) noexcept = default;
+        LoopWaiter(size_t tasks_number);
         ~LoopWaiter() = default;
-
         LoopWaiter& operator=(const LoopWaiter&) noexcept = default;
     private:
-        void count_down()
-        {
-            using std::memory_order_relaxed;
-            assert(m_status != nullptr);
-            m_status->count.fetch_sub(1, memory_order_relaxed);
-
-            if (m_status->count.load(memory_order_relaxed) == 0) {
-                m_status->waiter.notify_one();
-            }
-        }
+        inline void count_down();
     public:
-        void wait()
-        {
-            using std::memory_order_relaxed;
-            using std::unique_lock;
-            using std::mutex;
-
-            assert(m_status != nullptr);
-            if (m_status->count.load(memory_order_relaxed) > 0) {
-                unique_lock<mutex> lock(m_status->mutex);
-                m_status->waiter.wait(
-                    lock,
-                    [this]() {
-                        return this->m_status->count.load(memory_order_relaxed) == 0;
-                    }
-                );
-            }
-        }
+        inline void wait();
     private:
         std::shared_ptr<Wrapper> m_status;
-
         friend class ThreadPool;
     };
 
@@ -97,139 +61,30 @@ namespace ztools {
         static constexpr unsigned default_task_priority = 5;
         static constexpr unsigned default_looped_times_in_one_task = 15;
 
-        std::pair<unsigned, unsigned> get_threads_number_limit() const noexcept
-        {
-            return {
-                m_min_threads_number, m_max_threads_number
-            };
-        }
+        inline std::pair<unsigned, unsigned> get_threads_number_limit() const noexcept;
     private:
         static void executor_func(ThreadPool& pool) noexcept;
-        void create_thread()
-        {
-            using std::memory_order_release;
-            using std::thread;
-            using std::ref;
-
-            ++m_threads_number;
-            m_free_threads_number.fetch_add(1, memory_order_release);
-            thread{ executor_func, ref(*this) }.detach();
-        }
+        inline void create_thread();
     public:
-        ThreadPool()
-            : ThreadPool(
-                std::max(std::thread::hardware_concurrency() / 2, 1U),
-                std::thread::hardware_concurrency()
-            ) {}
-
-        ThreadPool(std::chrono::steady_clock::duration timeout_len)
-            : ThreadPool(
-                std::max(std::thread::hardware_concurrency() / 2, 1U),
-                std::thread::hardware_concurrency(),
-                timeout_len
-            ) {}
-
+        ThreadPool();
+        ThreadPool(std::chrono::steady_clock::duration timeout_len);
         ThreadPool(
             unsigned min_threads_number,
-            unsigned max_threads_number, 
+            unsigned max_threads_number,
             std::chrono::steady_clock::duration timeout_len = std::chrono::seconds{ 1 }
-        )
-            : m_threads_number(0)
-            , m_free_threads_number(0)
-            , m_stop(false)
-            , m_min_threads_number(min_threads_number)
-            , m_max_threads_number(max_threads_number)
-            , m_timeout_len(timeout_len)
-        {
-            using std::thread;
-            using std::ref;
-
-            for (unsigned i = 0; i < min_threads_number; ++i) {
-                create_thread();
-            }
-        }
-
+        );
         ThreadPool(const ThreadPool&) = delete;
+        ~ThreadPool();
         ThreadPool& operator=(const ThreadPool&) = delete;
         bool operator==(const ThreadPool&) = delete;
-        
-        ~ThreadPool()
-        {
-            using std::lock_guard;
-            using std::mutex;
-            namespace this_thread = std::this_thread;
 
-            {
-                lock_guard<mutex> lock(m_mutex);
-                m_stop = true;
-            }
-
-            m_scheduler.notify_all();
-
-            while (m_threads_number > 0) {
-                this_thread::yield();
-            }
-        }
-
-        void wait_all()
-        {
-            using std::memory_order_relaxed;
-            namespace this_thread = std::this_thread;
-            while (!(m_tasks.empty() && m_threads_number ==
-                m_free_threads_number.load(memory_order_relaxed))) {
-                this_thread::yield();
-            }
-        }
-
+        void wait_all();
         template <typename Func, typename... Args>
         auto add_task(unsigned priority, Func&& func, Args&&... args)
-            -> std::future<decltype(std::forward<Func>(func)(std::forward<Args>(args)...))>
-        {
-            using std::memory_order_acquire;
-            using std::lock_guard;
-            using std::mutex;
-            using std::packaged_task;
-            using std::bind;
-            using std::forward;
-            using std::make_shared;
-            using std::move;
-            using std::ref;
-            using result_type = decltype(forward<Func>(func)(forward<Args>(args)...));
-
-            auto task_func = make_shared<packaged_task<result_type()>>(
-                bind(forward<Func>(func), forward<Args>(args)...)
-            );
-
-            Task task{
-                [task_func] {
-                    (*task_func)();
-                },
-                priority
-            };
-
-            {
-                lock_guard<mutex> lock(m_mutex);
-
-                if (m_free_threads_number.load(memory_order_acquire) == 0 &&
-                    m_threads_number < get_threads_number_limit().second) {
-                    create_thread();
-                }
-
-                m_tasks.emplace(move(task));
-            }
-
-            m_scheduler.notify_one();
-            return task_func->get_future();
-        }
-
+            -> std::future<decltype(std::forward<Func>(func)(std::forward<Args>(args)...))>;
         template <typename Func, typename... Args>
         auto add_task(Func&& func, Args&&... args)
-            -> std::future<decltype(std::forward<Func>(func)(std::forward<Args>(args)...))>
-        {
-            using std::forward;
-            return add_task(default_task_priority, forward<Func>(func), forward<Args>(args)...);
-        }
-
+            -> std::future<decltype(std::forward<Func>(func)(std::forward<Args>(args)...))>;
         template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
             std::forward_iterator_tag, typename Iter::iterator_category>::value, int>::type = 0>
         LoopWaiter add_loop_n(
@@ -238,65 +93,7 @@ namespace ztools {
             Iter begin,
             std::size_t n,
             Func&& func
-        )
-        {
-            using std::size_t;
-            using std::forward;
-            using std::make_shared;
-            using function_type = typename std::decay<Func>::type;
-
-            size_t tasks_number = n / one_task_processing_number;
-            size_t remaining_number = n % one_task_processing_number;
-            LoopWaiter waiter(tasks_number);
-            auto packaged_func = make_shared<function_type>(forward<Func>(func));
-
-            if (n < one_task_processing_number) {
-                add_task(
-                    priority,
-                    [packaged_func, waiter](Iter begin, Iter end) mutable noexcept {
-                        for (; begin != end; ++begin) {
-                            (*packaged_func)(*begin);
-                        }
-
-                        waiter.count_down();
-                    },
-                    begin, begin + n
-                );
-            } else {
-                // Create tasks_number - 1 tasks
-                while (--tasks_number) {
-                    add_task(
-                        priority,
-                        [packaged_func, waiter](Iter begin, Iter end) mutable noexcept {
-                            for (; begin != end; ++begin) {
-                                (*packaged_func)(*begin);
-                            }
-
-                            waiter.count_down();
-                        },
-                        begin, begin + one_task_processing_number
-                    );
-
-                    begin += one_task_processing_number;
-                }
-
-                // Create the last task
-                add_task(
-                    priority,
-                    [packaged_func, waiter](Iter begin, Iter end) mutable noexcept {
-                        for (; begin != end; ++begin) {
-                            (*packaged_func)(*begin);
-                        }
-
-                        waiter.count_down();
-                    },
-                    begin, begin + one_task_processing_number + remaining_number
-                );
-            }
-
-            return waiter;
-        }
-
+        );
         template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
             std::forward_iterator_tag, typename Iter::iterator_category>::value, int>::type = 0>
         LoopWaiter add_loop_n(
@@ -304,39 +101,14 @@ namespace ztools {
             Iter begin,
             std::size_t n,
             Func&& func
-        )
-        {
-            using std::forward;
-            using std::move;
-
-            return add_loop_n(
-                default_task_priority,
-                one_task_processing_number,
-                move(begin),
-                n,
-                forward<Func>(func)
-            );
-        }
-
+        );
         template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
             std::forward_iterator_tag, typename Iter::iterator_category>::value, int>::type = 0>
         LoopWaiter add_loop_n(
             Iter begin,
             std::size_t n,
             Func&& func
-        )
-        {
-            using std::forward;
-            using std::move;
-
-            return add_loop_n(
-                default_looped_times_in_one_task,
-                move(begin),
-                n,
-                forward<Func>(func)
-            );
-        }
-
+        );
         template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
             std::random_access_iterator_tag, typename Iter::iterator_category>::value, int>::type =
             0>
@@ -346,20 +118,7 @@ namespace ztools {
             Iter begin,
             Iter end,
             Func&& func
-        )
-        {
-            using std::forward;
-            using std::move;
-
-            return add_loop_n(
-                priority,
-                one_task_processing_number,
-                move(begin),
-                end - begin,
-                forward<Func>(func)
-            );
-        }
-
+        );
         template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
             std::random_access_iterator_tag, typename Iter::iterator_category>::value, int>::type =
             0>
@@ -368,20 +127,7 @@ namespace ztools {
             Iter begin,
             Iter end,
             Func&& func
-        )
-        {
-            using std::forward;
-            using std::move;
-
-            return add_loop(
-                default_task_priority,
-                one_task_processing_number,
-                move(begin),
-                move(end),
-                forward<Func>(func)
-            );
-        }
-
+        );
         template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
             std::random_access_iterator_tag, typename Iter::iterator_category>::value, int>::type =
             0>
@@ -389,22 +135,13 @@ namespace ztools {
             Iter begin,
             Iter end,
             Func&& func
-        )
-        {
-            using std::forward;
-            using std::move;
-
-            return add_loop(
-                default_looped_times_in_one_task,
-                move(begin),
-                move(end),
-                forward<Func>(func)
-            );
-        }
+        );
     private:
         std::mutex m_mutex;
         std::condition_variable m_scheduler;
         std::atomic_uint m_free_threads_number;
+        std::atomic_ullong m_added_tasks_number;
+        std::atomic_ullong m_finished_tasks_number;
 
         // Access is all in a locked environment, so there is no need for atomic variables.
         unsigned m_threads_number;
@@ -414,5 +151,278 @@ namespace ztools {
         std::chrono::steady_clock::duration m_timeout_len;
         std::priority_queue<Task, std::vector<Task>, TaskPriorityLess> m_tasks;
     };
+
+    inline bool TaskPriorityLess::operator()(const Task& left, const Task& right) const noexcept
+    {
+        return left.priority > right.priority;
+    }
+
+    inline void LoopWaiter::count_down()
+    {
+        using std::memory_order_relaxed;
+        assert(m_status != nullptr);
+        m_status->count.fetch_sub(1, memory_order_relaxed);
+
+        if (m_status->count.load(memory_order_relaxed) == 0) {
+            m_status->waiter.notify_one();
+        }
+    }
+
+    inline void LoopWaiter::wait()
+    {
+        using std::memory_order_relaxed;
+        using std::unique_lock;
+        using std::mutex;
+
+        assert(m_status != nullptr);
+        if (m_status->count.load(memory_order_relaxed) > 0) {
+            unique_lock<mutex> lock(m_status->mutex);
+            m_status->waiter.wait(
+                lock,
+                [this]() {
+                    return this->m_status->count.load(memory_order_relaxed) == 0;
+                }
+            );
+        }
+    }
+
+    inline std::pair<unsigned, unsigned> ThreadPool::get_threads_number_limit() const noexcept
+    {
+        return {
+            m_min_threads_number, m_max_threads_number
+        };
+    }
+
+    inline void ThreadPool::create_thread()
+    {
+        using std::memory_order_relaxed;
+        using std::thread;
+        using std::ref;
+
+        ++m_threads_number;
+        m_free_threads_number.fetch_add(1, memory_order_relaxed);
+        thread{ executor_func, ref(*this) }.detach();
+    }
+
+    template <typename Func, typename... Args>
+    auto ThreadPool::add_task(unsigned priority, Func&& func, Args&&... args)
+        -> std::future<decltype(std::forward<Func>(func)(std::forward<Args>(args)...))>
+    {
+        using std::memory_order_relaxed;
+        using std::lock_guard;
+        using std::mutex;
+        using std::packaged_task;
+        using std::bind;
+        using std::forward;
+        using std::make_shared;
+        using std::move;
+        using std::ref;
+        using result_type = decltype(forward<Func>(func)(forward<Args>(args)...));
+
+        auto task_func = make_shared<packaged_task<result_type()>>(
+            bind(forward<Func>(func), forward<Args>(args)...)
+        );
+
+        Task task{
+            [task_func] {
+                (*task_func)();
+            },
+            priority
+        };
+
+        {
+            lock_guard<mutex> lock(m_mutex);
+            // TODO: ÐÞ¸´ThreadPoolµÄBug
+
+            if (m_free_threads_number.load(memory_order_relaxed) == 0 &&
+                m_threads_number < get_threads_number_limit().second) {
+                create_thread();
+            }
+
+            m_added_tasks_number.fetch_add(1, memory_order_relaxed);
+            m_tasks.emplace(move(task));
+        }
+
+        m_scheduler.notify_one();
+        return task_func->get_future();
+    }
+
+    template <typename Func, typename... Args>
+    auto ThreadPool::add_task(Func&& func, Args&&... args)
+        -> std::future<decltype(std::forward<Func>(func)(std::forward<Args>(args)...))>
+    {
+        using std::forward;
+        return add_task(default_task_priority, forward<Func>(func), forward<Args>(args)...);
+    }
+
+    template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
+        std::forward_iterator_tag, typename Iter::iterator_category>::value, int>::type>
+    LoopWaiter ThreadPool::add_loop_n(
+        unsigned priority,
+        std::size_t one_task_processing_number,
+        Iter begin,
+        std::size_t n,
+        Func&& func
+    )
+    {
+        using std::size_t;
+        using std::forward;
+        using std::make_shared;
+        using std::max;
+        using function_type = typename std::decay<Func>::type;
+
+        size_t tasks_number = max<size_t>(n / one_task_processing_number, 1);
+        size_t remaining_number = n % one_task_processing_number;
+        LoopWaiter waiter(tasks_number);
+        auto packaged_func = make_shared<function_type>(forward<Func>(func));
+
+        if (n < one_task_processing_number) {
+            add_task(
+                priority,
+                [packaged_func, waiter](Iter begin, Iter end) mutable noexcept {
+                    for (; begin != end; ++begin) {
+                        (*packaged_func)(*begin);
+                    }
+
+                    waiter.count_down();
+                },
+                begin, begin + n
+            );
+        } else {
+            // Create tasks_number - 1 tasks
+            while (--tasks_number) {
+                add_task(
+                    priority,
+                    [packaged_func, waiter](Iter begin, Iter end) mutable noexcept {
+                        for (; begin != end; ++begin) {
+                            (*packaged_func)(*begin);
+                        }
+
+                        waiter.count_down();
+                    },
+                    begin, begin + one_task_processing_number
+                );
+
+                begin += one_task_processing_number;
+            }
+
+            // Create the last task
+            add_task(
+                priority,
+                [packaged_func, waiter](Iter begin, Iter end) mutable noexcept {
+                    for (; begin != end; ++begin) {
+                        (*packaged_func)(*begin);
+                    }
+
+                    waiter.count_down();
+                },
+                begin, begin + one_task_processing_number + remaining_number
+            );
+        }
+
+        return waiter;
+    }
+
+    template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
+        std::forward_iterator_tag, typename Iter::iterator_category>::value, int>::type>
+    LoopWaiter ThreadPool::add_loop_n(
+        std::size_t one_task_processing_number,
+        Iter begin,
+        std::size_t n,
+        Func&& func
+    )
+    {
+        using std::forward;
+        using std::move;
+
+        return add_loop_n(
+            default_task_priority,
+            one_task_processing_number,
+            move(begin),
+            n,
+            forward<Func>(func)
+        );
+    }
+
+    template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
+        std::forward_iterator_tag, typename Iter::iterator_category>::value, int>::type>
+    LoopWaiter ThreadPool::add_loop_n(
+        Iter begin,
+        std::size_t n,
+        Func&& func
+    )
+    {
+        using std::forward;
+        using std::move;
+
+        return add_loop_n(
+            default_looped_times_in_one_task,
+            move(begin),
+            n,
+            forward<Func>(func)
+        );
+    }
+
+    template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
+        std::random_access_iterator_tag, typename Iter::iterator_category>::value, int>::type>
+    LoopWaiter ThreadPool::add_loop(
+        unsigned priority,
+        std::size_t one_task_processing_number,
+        Iter begin,
+        Iter end,
+        Func&& func
+    )
+    {
+        using std::forward;
+        using std::move;
+
+        return add_loop_n(
+            priority,
+            one_task_processing_number,
+            move(begin),
+            end - begin,
+            forward<Func>(func)
+        );
+    }
+
+    template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
+        std::random_access_iterator_tag, typename Iter::iterator_category>::value, int>::type>
+    LoopWaiter ThreadPool::add_loop(
+        std::size_t one_task_processing_number,
+        Iter begin,
+        Iter end,
+        Func&& func
+    )
+    {
+        using std::forward;
+        using std::move;
+
+        return add_loop(
+            default_task_priority,
+            one_task_processing_number,
+            move(begin),
+            move(end),
+            forward<Func>(func)
+        );
+    }
+
+    template <typename Iter, typename Func, typename std::enable_if<std::is_base_of<
+        std::random_access_iterator_tag, typename Iter::iterator_category>::value, int>::type>
+    LoopWaiter ThreadPool::add_loop(
+        Iter begin,
+        Iter end,
+        Func&& func
+    )
+    {
+        using std::forward;
+        using std::move;
+
+        return add_loop(
+            default_looped_times_in_one_task,
+            move(begin),
+            move(end),
+            forward<Func>(func)
+        );
+    }
 }
 #endif // ZTOOLS_THREAD_POOL_H_


### PR DESCRIPTION
# 变化

1. 修复了2个bug：
   1. `ztools::ThreadPool::wait_all`函数 **无法等待线程池把已经存在于队列中的任务执行完毕** 
   2. `ztools::ThreadPool::add_loop_n`方法 **在参数`n`小于参数`one_task_processing_number`时返回的`ztools::LoopWaiter`对象无效。

2. 对代码格式进行了改变：
   分离了类内函数的声明与实现，将部分移至源文件，部分移至头文件尾部。

3. 添加了单元测试